### PR TITLE
feat: simplify the API - mock by default when only typeDefs passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ npm install --save-dev federation-testing-tool
 
 Example Usage, for the [Federation Demo From Apollo](https://github.com/apollographql/federation-demo).
 
-Demo with the whole repositorium, code examples, and walk-through tutorial coming this weekend! Stay tuned.
+Demo with the whole repositorium, code examples, and walk-through tutorial coming soon! Stay tuned.
 
 ![data flow](https://cdn-images-1.medium.com/max/1200/1*z8EJo-cCafi7tdyxOvW2_w.png)
 
@@ -105,7 +105,7 @@ const { resolvers } = require("./resolvers");
 const { typeDefs: typeDefsProducts } = require("../products/schema");
 
 const services = [
-  { inventory: { typeDefs, resolvers, underTest: true } },
+  { inventory: { typeDefs, resolvers } },
   {
     products: {
       typeDefs: typeDefsProducts

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ const setupSchema = serviceOrServices => {
         serviceUnderTest: {
           resolvers: serviceOrServices.resolvers,
           typeDefs: serviceOrServices.typeDefs,
-          underTest: true
+          addMocks: serviceOrServices.addMocks
         }
       }
     ];
@@ -96,8 +96,11 @@ const setupSchema = serviceOrServices => {
   let serviceMap = {};
   services.forEach(service => {
     let serviceName = Object.keys(service)[0];
+    if (!service[serviceName].resolvers) {
+      service[serviceName].addMocks = true;
+    }
     serviceMap[serviceName] = buildLocalService([service[serviceName]]);
-    serviceMap[serviceName].__underTest__ = service[serviceName].underTest;
+    serviceMap[serviceName].__addMocks__ = service[serviceName].addMocks;
   });
 
   let mapForComposeServices = Object.entries(serviceMap).map(
@@ -118,7 +121,7 @@ const setupSchema = serviceOrServices => {
 function setupMocks(serviceMap, mocks) {
   Object.values(serviceMap).forEach(service => {
     let resolvers = {};
-    if (!service.__underTest__) {
+    if (service.__addMocks__) {
       Object.entries(mocks).forEach(([type, value]) => {
         resolvers[type] = {
           __resolveReference() {
@@ -174,16 +177,16 @@ function validateArguments(
 }
 
 const executeGraphql = ({
-                          query,
-                          mutation,
-                          variables,
-                          context,
-                          services,
-                          mocks = {},
-                          schema,
-                          serviceMap,
-                          service
-                        }) => {
+  query,
+  mutation,
+  variables,
+  context,
+  services,
+  mocks = {},
+  schema,
+  serviceMap,
+  service
+}) => {
   validateArguments(services, service, schema, serviceMap, query, mutation);
 
   if (services || service) {

--- a/tests/multipleServices.test.js
+++ b/tests/multipleServices.test.js
@@ -53,8 +53,7 @@ const services = [
   {
     inventory: {
       typeDefs: typeDefsInventory,
-      resolvers: resolversInventory,
-      underTest: true
+      resolvers: resolversInventory
     }
   },
   {
@@ -179,8 +178,7 @@ test("should allow for using mutations, having all resolvers implemented", async
     {
       inventory: {
         typeDefs: typeDefsInventory,
-        resolvers: resolversInventory,
-        underTest: true
+        resolvers: resolversInventory
       }
     },
     {
@@ -196,8 +194,7 @@ test("should allow for using mutations, having all resolvers implemented", async
           }
         },
         typeDefs: typeDefsProducts
-      },
-      underTest: true
+      }
     }
   ];
 
@@ -223,8 +220,7 @@ test("should allow mocking the context and passing it to the resolvers", async (
           Mutation: {
             returnContext: (_, args, context) => context.stringToBeReturned
           }
-        },
-        underTest: true
+        }
       }
     },
     {


### PR DESCRIPTION
BREAKING CHANGE: if you relied on the tool to auto add mocks for you, you will have to manually add addMocks: true to the services that need them.
If you set underTest: true for services that had resolvers defined you don't need to do anything - they will NOT be mocked by default now.